### PR TITLE
Added centerXTo(_ anchor:) and centerYTo(_ anchor:) convenience methods

### DIFF
--- a/Source/Extensions/UIView+Layout.swift
+++ b/Source/Extensions/UIView+Layout.swift
@@ -96,6 +96,20 @@ extension UIView {
         }
     }
     
+    open func centerXTo(_ anchor: NSLayoutXAxisAnchor?) {
+        translatesAutoresizingMaskIntoConstraints = false
+        if let xAxisAnchor = anchor {
+            centerXAnchor.constraint(equalTo: xAxisAnchor).isActive = true
+        }
+    }
+    
+    open func centerYTo(_ anchor: NSLayoutYAxisAnchor?) {
+        translatesAutoresizingMaskIntoConstraints = false
+        if let yAxisAnchor = anchor {
+            centerYAnchor.constraint(equalTo: yAxisAnchor).isActive = true
+        }
+    }
+    
     open func centerXToSuperview() {
         translatesAutoresizingMaskIntoConstraints = false
         if let superviewCenterXAnchor = superview?.centerXAnchor {

--- a/Source/Extensions/UIView+Layout.swift
+++ b/Source/Extensions/UIView+Layout.swift
@@ -96,18 +96,14 @@ extension UIView {
         }
     }
     
-    open func centerXTo(_ anchor: NSLayoutXAxisAnchor?) {
+    open func centerXTo(_ anchor: NSLayoutXAxisAnchor) {
         translatesAutoresizingMaskIntoConstraints = false
-        if let xAxisAnchor = anchor {
-            centerXAnchor.constraint(equalTo: xAxisAnchor).isActive = true
-        }
+        centerXAnchor.constraint(equalTo: anchor).isActive = true
     }
     
-    open func centerYTo(_ anchor: NSLayoutYAxisAnchor?) {
+    open func centerYTo(_ anchor: NSLayoutYAxisAnchor) {
         translatesAutoresizingMaskIntoConstraints = false
-        if let yAxisAnchor = anchor {
-            centerYAnchor.constraint(equalTo: yAxisAnchor).isActive = true
-        }
+        centerYAnchor.constraint(equalTo: anchor).isActive = true
     }
     
     open func centerXToSuperview() {


### PR DESCRIPTION
Added more general centering methods for anchoring views (not limited to superview's center-anchors as per existing centerXToSuperview() centerYToSuperview() methods).