### PR TITLE
Remove text as required parameter in label init method

### DIFF
--- a/Source/Extensions/UILabel.swift
+++ b/Source/Extensions/UILabel.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 extension UILabel {
-    convenience public init(text: String?, font: UIFont? = UIFont.systemFont(ofSize: 14), textColor: UIColor = .black, textAlignment: NSTextAlignment = .left, numberOfLines: Int = 1) {
+    convenience public init(text: String? = nil, font: UIFont? = UIFont.systemFont(ofSize: 14), textColor: UIColor = .black, textAlignment: NSTextAlignment = .left, numberOfLines: Int = 1) {
         self.init()
         self.text = text
         self.font = font


### PR DESCRIPTION
Not able to init label like so:

`let label = UILabel(font: ..., numberOfLines: 0)`