### PR TITLE
StackView set isUserInteractionEnabled false.

### DIFF
--- a/Source/Extensions/UIView+Stacking.swift
+++ b/Source/Extensions/UIView+Stacking.swift
@@ -19,6 +19,7 @@ extension UIView {
         stackView.distribution = distribution
         addSubview(stackView)
         stackView.fillSuperview()
+        stackView.isUserInteractionEnabled = false
         return stackView
     }
     


### PR DESCRIPTION
When the stack is used on inside a button, the button cannot be clicked.