### PR TITLE
Add constrainSize method + replace !=0 with >0 checks in UIView+Layout.swift

### DIFF
--- a/Source/Extensions/UIView+Layout.swift
+++ b/Source/Extensions/UIView+Layout.swift
@@ -113,32 +113,6 @@ extension UIView {
         }
         return anchor(top: superviewTopAnchor, leading: superviewLeadingAnchor, bottom: superviewBottomAnchor, trailing: superviewTrailingAnchor, padding: padding)
     }
-
-    @discardableResult
-    open func constrainHeight(_ constant: CGFloat) -> AnchoredConstraints {
-        translatesAutoresizingMaskIntoConstraints = false
-        var anchoredConstraints = AnchoredConstraints()
-        anchoredConstraints.height = heightAnchor.constraint(equalToConstant: constant)
-        anchoredConstraints.height?.isActive = true
-        return anchoredConstraints
-    }
-    
-    @discardableResult
-    open func constrainWidth(_ constant: CGFloat) -> AnchoredConstraints {
-        translatesAutoresizingMaskIntoConstraints = false
-        var anchoredConstraints = AnchoredConstraints()
-        anchoredConstraints.width = widthAnchor.constraint(equalToConstant: constant)
-        anchoredConstraints.width?.isActive = true
-        return anchoredConstraints
-    }
-    
-    @discardableResult
-    open func constrainSize(_ size: CGSize) -> AnchoredConstraints {
-        var anchoredConstraints = AnchoredConstraints()
-        anchoredConstraints.width = constrainWidth(size.width).width
-        anchoredConstraints.height = constrainHeight(size.height).height
-        return anchoredConstraints
-    }
     
     open func centerInSuperview(size: CGSize = .zero) {
         translatesAutoresizingMaskIntoConstraints = false
@@ -185,8 +159,9 @@ extension UIView {
     
     @discardableResult
     open func constrainHeight(_ constant: CGFloat) -> AnchoredConstraints {
-        translatesAutoresizingMaskIntoConstraints = false
         var anchoredConstraints = AnchoredConstraints()
+        guard constant > 0 else { return anchoredConstraints }
+        translatesAutoresizingMaskIntoConstraints = false
         anchoredConstraints.height = heightAnchor.constraint(equalToConstant: constant)
         anchoredConstraints.height?.isActive = true
         return anchoredConstraints
@@ -194,10 +169,19 @@ extension UIView {
     
     @discardableResult
     open func constrainWidth(_ constant: CGFloat) -> AnchoredConstraints {
-        translatesAutoresizingMaskIntoConstraints = false
         var anchoredConstraints = AnchoredConstraints()
+        guard constant > 0 else { return anchoredConstraints }
+        translatesAutoresizingMaskIntoConstraints = false
         anchoredConstraints.width = widthAnchor.constraint(equalToConstant: constant)
         anchoredConstraints.width?.isActive = true
+        return anchoredConstraints
+    }
+    
+    @discardableResult
+    open func constrainSize(_ size: CGSize) -> AnchoredConstraints {
+        var anchoredConstraints = AnchoredConstraints()
+        anchoredConstraints.width = constrainWidth(size.width).width
+        anchoredConstraints.height = constrainHeight(size.height).height
         return anchoredConstraints
     }
     

--- a/Source/Extensions/UIView+Layout.swift
+++ b/Source/Extensions/UIView+Layout.swift
@@ -79,11 +79,11 @@ extension UIView {
             anchoredConstraints.trailing = trailingAnchor.constraint(equalTo: trailing, constant: -padding.right)
         }
         
-        if size.width != 0 {
+        if size.width > 0 {
             anchoredConstraints.width = widthAnchor.constraint(equalToConstant: size.width)
         }
         
-        if size.height != 0 {
+        if size.height > 0 {
             anchoredConstraints.height = heightAnchor.constraint(equalToConstant: size.height)
         }
         
@@ -94,28 +94,50 @@ extension UIView {
     
     @discardableResult
     open func fillSuperview(padding: UIEdgeInsets = .zero) -> AnchoredConstraints {
-        translatesAutoresizingMaskIntoConstraints = false
-        let anchoredConstraints = AnchoredConstraints()
         guard let superviewTopAnchor = superview?.topAnchor,
             let superviewBottomAnchor = superview?.bottomAnchor,
             let superviewLeadingAnchor = superview?.leadingAnchor,
             let superviewTrailingAnchor = superview?.trailingAnchor else {
-                return anchoredConstraints
+                return AnchoredConstraints()
         }
-        
         return anchor(top: superviewTopAnchor, leading: superviewLeadingAnchor, bottom: superviewBottomAnchor, trailing: superviewTrailingAnchor, padding: padding)
     }
     
     @discardableResult
     open func fillSuperviewSafeAreaLayoutGuide(padding: UIEdgeInsets = .zero) -> AnchoredConstraints {
-        let anchoredConstraints = AnchoredConstraints()
         guard let superviewTopAnchor = superview?.safeAreaLayoutGuide.topAnchor,
             let superviewBottomAnchor = superview?.safeAreaLayoutGuide.bottomAnchor,
             let superviewLeadingAnchor = superview?.safeAreaLayoutGuide.leadingAnchor,
             let superviewTrailingAnchor = superview?.safeAreaLayoutGuide.trailingAnchor else {
-                return anchoredConstraints
+                return AnchoredConstraints()
         }
         return anchor(top: superviewTopAnchor, leading: superviewLeadingAnchor, bottom: superviewBottomAnchor, trailing: superviewTrailingAnchor, padding: padding)
+    }
+
+    @discardableResult
+    open func constrainHeight(_ constant: CGFloat) -> AnchoredConstraints {
+        translatesAutoresizingMaskIntoConstraints = false
+        var anchoredConstraints = AnchoredConstraints()
+        anchoredConstraints.height = heightAnchor.constraint(equalToConstant: constant)
+        anchoredConstraints.height?.isActive = true
+        return anchoredConstraints
+    }
+    
+    @discardableResult
+    open func constrainWidth(_ constant: CGFloat) -> AnchoredConstraints {
+        translatesAutoresizingMaskIntoConstraints = false
+        var anchoredConstraints = AnchoredConstraints()
+        anchoredConstraints.width = widthAnchor.constraint(equalToConstant: constant)
+        anchoredConstraints.width?.isActive = true
+        return anchoredConstraints
+    }
+    
+    @discardableResult
+    open func constrainSize(_ size: CGSize) -> AnchoredConstraints {
+        var anchoredConstraints = AnchoredConstraints()
+        anchoredConstraints.width = constrainWidth(size.width).width
+        anchoredConstraints.height = constrainHeight(size.height).height
+        return anchoredConstraints
     }
     
     open func centerInSuperview(size: CGSize = .zero) {
@@ -128,11 +150,11 @@ extension UIView {
             centerYAnchor.constraint(equalTo: superviewCenterYAnchor).isActive = true
         }
         
-        if size.width != 0 {
+        if size.width > 0 {
             widthAnchor.constraint(equalToConstant: size.width).isActive = true
         }
         
-        if size.height != 0 {
+        if size.height > 0 {
             heightAnchor.constraint(equalToConstant: size.height).isActive = true
         }
     }


### PR DESCRIPTION
Added `constrainSize(_ size: CGSize) -> AnchoredConstraints` method, replaced old !=0 checks with >0 for width/height constraints (matching new variadic `anchor` method) & removed moot `translatesAutoresizingMaskIntoConstraints = false` setting in `fillSuperview(SafeAreaLayoutGuide)` methods (as following `anchor` call does this). Also removed unused `let anchoredConstraints = AnchoredConstraints()` declaration in `fillSuperview(SafeAreaLayoutGuide)` methods.

Tweaks to `constrainWidth/Height` ensure that an invalid constant (i.e. one that is ≤0) does not alter view.